### PR TITLE
Feature/passm 17 create docker compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,19 @@ Download according to your OS.
   ```
   gradle bootRun
   ```
+
+  ### How to run the docker compose file
+
+  - Install Docker from [Docker official website](https://www.docker.com/). Check your OS and download accordingly.
+
+  - Build the Docker Image with this command. Make sure docker engine is running before running this command. (Simply open docker desktop to boot the docker engine)
+
+  ```
+  gradle bootBuildImage
+  ```
+
+  - Once the Docker Image is built, use the following command to run the services defined in the `docker-compose.yml` file. (Docker engine must be running.)
+
+  ```
+  docker compose up
+  ```

--- a/build.gradle
+++ b/build.gradle
@@ -45,5 +45,5 @@ bootRun {
 }
 
 bootBuildImage{
-	imageName = 'atharva0418/springboot-gradle-app'
+	imageName = 'pwm-backend-img'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -43,3 +43,7 @@ bootRun {
 	sourceResources sourceSets.main
 
 }
+
+bootBuildImage{
+	imageName = 'atharva0418/springboot-gradle-app'
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: '3.8'
+
+services:
+  app:
+    image: atharva0418/springboot-gradle-app
+    container_name: springboot-app
+    ports:
+      - 3000:3000
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/test
+      SPRING_DATASOURCE_USERNAME: root
+      SPRING_DATASOURCE_PASSWORD: root
+    depends_on:
+      - db
+
+  db:
+    image: mysql
+    container_name: mysqldb
+    environment:
+      MYSQL_DATABASE: test
+      MYSQL_ROOT_PASSWORD: root
+    ports:
+      - 3306:3306

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   app:
-    image: atharva0418/springboot-gradle-app
-    container_name: springboot-app
+    image: pwm-backend-img
+    container_name: pwm-backend-app
     ports:
       - 3000:3000
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     image: atharva0418/springboot-gradle-app
@@ -7,11 +5,13 @@ services:
     ports:
       - 3000:3000
     environment:
-      SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/test
+      SPRING_DATASOURCE_URL: jdbc:mysql://mysqldb:3306/test
       SPRING_DATASOURCE_USERNAME: root
       SPRING_DATASOURCE_PASSWORD: root
     depends_on:
       - db
+    networks:
+      - app-network
 
   db:
     image: mysql
@@ -20,4 +20,15 @@ services:
       MYSQL_DATABASE: test
       MYSQL_ROOT_PASSWORD: root
     ports:
-      - 3306:3306
+      - 3307:3306
+    volumes:
+      - mysql_data:/var/lib/mysql
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  mysql_data:

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,9 +10,10 @@ spring.profiles.active=dev
 spring.datasource.url=${DB_URL}
 spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
-spring.datasource.driver-class-name=${DB_DRIVER_CLASS_NAME}
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
 
 


### PR DESCRIPTION
This pull request adds a Docker Compose file to simplify the setup and management of the Spring Boot application and its MySQL database. The configuration includes:

App Service:

- Uses the image atharva0418/springboot-gradle-app.
- Exposes port 3000 and sets environment variables for database connection.
- Depends on the MySQL service.

DB Service:

- Uses the official MySQL image.
- Creates a database named test with root password root.
- Exposes port 3307 on the host.
- Networking and Volumes:

- Configures a custom network (app-network) for inter-container communication.
- Uses a volume (mysql_data) to persist MySQL data.

Benefits: This configuration allows for easy deployment and consistent environment setup for all developers using a single command (docker-compose up).