### PR TITLE
feature/passm-18-Implement-Simple-Encryption-For-Passwords

### DIFF
--- a/src/main/java/com/atharvadholakia/password_manager/service/CredentialService.java
+++ b/src/main/java/com/atharvadholakia/password_manager/service/CredentialService.java
@@ -64,6 +64,9 @@ public class CredentialService {
 
   public List<Credential> getAllCredentials() {
     log.info("Calling repository to get all the credentials");
+    List<Credential> credentials = credentialRepository.findAll();
+    credentials.forEach(
+        credential -> credential.setPassword(encryptionService.decrypt(credential.getPassword())));
     return credentialRepository.findAll();
   }
 

--- a/src/main/java/com/atharvadholakia/password_manager/service/CredentialService.java
+++ b/src/main/java/com/atharvadholakia/password_manager/service/CredentialService.java
@@ -67,7 +67,7 @@ public class CredentialService {
     List<Credential> credentials = credentialRepository.findAll();
     credentials.forEach(
         credential -> credential.setPassword(encryptionService.decrypt(credential.getPassword())));
-    return credentialRepository.findAll();
+    return credentials;
   }
 
   public void deleteCredentialById(String id) {

--- a/src/main/java/com/atharvadholakia/password_manager/service/CredentialService.java
+++ b/src/main/java/com/atharvadholakia/password_manager/service/CredentialService.java
@@ -3,6 +3,7 @@ package com.atharvadholakia.password_manager.service;
 import com.atharvadholakia.password_manager.data.Credential;
 import com.atharvadholakia.password_manager.exception.ResourceNotFoundException;
 import com.atharvadholakia.password_manager.repository.CredentialRepository;
+import com.atharvadholakia.password_manager.utils.EncryptionService;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -11,16 +12,21 @@ import org.springframework.stereotype.Service;
 @Slf4j
 public class CredentialService {
 
+  private final EncryptionService encryptionService;
+
   private final CredentialRepository credentialRepository;
 
-  public CredentialService(CredentialRepository credentialRepository) {
+  public CredentialService(
+      CredentialRepository credentialRepository, EncryptionService encryptionService) {
     this.credentialRepository = credentialRepository;
+    this.encryptionService = encryptionService;
   }
 
   public Credential createCredential(String serviceName, String username, String password) {
     Credential credential = new Credential(serviceName, username, password);
 
     log.info("Calling repository from service to write to DB.");
+    credential.setPassword(encryptionService.encrypt(password));
     credentialRepository.save(credential);
 
     log.debug("Exiting createCredential from service");
@@ -37,7 +43,7 @@ public class CredentialService {
       existingCredential.setServicename(serviceName);
     }
     if (!existingCredential.getPassword().equals(password)) {
-      existingCredential.setPassword(password);
+      existingCredential.setPassword(encryptionService.encrypt(password));
     }
 
     log.debug("Exiting updateCredential from service");
@@ -47,12 +53,13 @@ public class CredentialService {
 
   public Credential getCredentialById(String id) {
     log.info("Calling repository from service to get a credential with ID: {}", id);
-    return credentialRepository
-        .findById(id)
-        .orElseThrow(
-            () -> {
-              return new ResourceNotFoundException("Credential not found with ID " + id);
-            });
+    Credential credential =
+        credentialRepository
+            .findById(id)
+            .orElseThrow(() -> new ResourceNotFoundException("Credential not found with ID " + id));
+
+    credential.setPassword(encryptionService.decrypt(credential.getPassword()));
+    return credential;
   }
 
   public List<Credential> getAllCredentials() {

--- a/src/main/java/com/atharvadholakia/password_manager/utils/CaesarCipher.java
+++ b/src/main/java/com/atharvadholakia/password_manager/utils/CaesarCipher.java
@@ -1,0 +1,28 @@
+package com.atharvadholakia.password_manager.utils;
+
+public class CaesarCipher {
+
+  public static String encrypt(String plaintext, int shift) {
+    StringBuilder encryptedText = new StringBuilder();
+
+    for (char c : plaintext.toCharArray()) {
+
+      if (Character.isUpperCase(c)) {
+        char encryptedChar = (char) ((c + shift - 'A') % 26 + 'A');
+        encryptedText.append(encryptedChar);
+      } else if (Character.isLowerCase(c)) {
+        char encryptedChar = (char) ((c + shift - 'a') % 26 + 'a');
+        encryptedText.append(encryptedChar);
+      } else {
+        encryptedText.append(c);
+      }
+    }
+
+    return encryptedText.toString();
+  }
+
+  public static String decrypt(String plaintext, int shift) {
+
+    return encrypt(plaintext, 26 - (shift % 26));
+  }
+}

--- a/src/main/java/com/atharvadholakia/password_manager/utils/EncryptionService.java
+++ b/src/main/java/com/atharvadholakia/password_manager/utils/EncryptionService.java
@@ -1,0 +1,16 @@
+package com.atharvadholakia.password_manager.utils;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class EncryptionService {
+  private final int shift = 3;
+
+  public String encrypt(String text) {
+    return CaesarCipher.encrypt(text, shift);
+  }
+
+  public String decrypt(String text) {
+    return CaesarCipher.decrypt(text, shift);
+  }
+}

--- a/src/test/java/com/atharvadholakia/password_manager/service/CredentialServiceTests.java
+++ b/src/test/java/com/atharvadholakia/password_manager/service/CredentialServiceTests.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import com.atharvadholakia.password_manager.data.Credential;
 import com.atharvadholakia.password_manager.exception.ResourceNotFoundException;
 import com.atharvadholakia.password_manager.repository.CredentialRepository;
+import com.atharvadholakia.password_manager.utils.EncryptionService;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -24,6 +25,8 @@ public class CredentialServiceTests {
 
   @Mock private CredentialRepository credentialRepository;
 
+  @Mock private EncryptionService encryptionService;
+
   @InjectMocks private CredentialService credentialService;
 
   @BeforeEach
@@ -34,12 +37,14 @@ public class CredentialServiceTests {
   @Test
   public void testCreateCredential() throws Exception {
 
-    Credential credential = new Credential("TestServiceName", "TestUsername", "TestPassword");
+    Credential credential = new Credential("TestServiceName", "TestUsername", "TestP@ssword1");
+    credential.setPassword(encryptionService.encrypt(credential.getPassword()));
 
     when(credentialRepository.save(credential)).thenReturn(credential);
 
     Credential result =
-        credentialService.createCredential("TestServiceName", "TestUsername", "TestPassword");
+        credentialService.createCredential(
+            "TestServiceName", "TestUsername", encryptionService.encrypt(credential.getPassword()));
 
     assertEquals(credential.getServiceName(), result.getServiceName());
     assertEquals(credential.getUsername(), result.getUsername());
@@ -110,10 +115,11 @@ public class CredentialServiceTests {
     existingCredential =
         credentialService.updateCredential(
             existingCredential, "UpdatedServiceName", "UpdatedUsername", "UpdatedPassword@1");
+    existingCredential.setPassword(encryptionService.encrypt("UpdatedPassword@1"));
 
     assertEquals(existingCredential.getServiceName(), "UpdatedServiceName");
     assertEquals(existingCredential.getUsername(), "UpdatedUsername");
-    assertEquals(existingCredential.getPassword(), "UpdatedPassword@1");
+    assertEquals(existingCredential.getPassword(), encryptionService.encrypt("UpdatedPassword@1"));
 
     verify(credentialRepository).save(existingCredential);
   }

--- a/src/test/java/com/atharvadholakia/password_manager/utils/CaesarCipherTests.java
+++ b/src/test/java/com/atharvadholakia/password_manager/utils/CaesarCipherTests.java
@@ -1,0 +1,22 @@
+package com.atharvadholakia.password_manager.utils;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class CaesarCipherTests {
+
+  @Test
+  void testEncrypt() {
+    String plaintext = "HELLO";
+    String encryptedText = "KHOOR";
+    assertEquals(encryptedText, CaesarCipher.encrypt(plaintext, 3));
+  }
+
+  @Test
+  void testDecrypt() {
+    String encryptedText = "KHOOR";
+    String plaintext = "HELLO";
+    assertEquals(plaintext, CaesarCipher.decrypt(encryptedText, 3));
+  }
+}

--- a/src/test/java/com/atharvadholakia/password_manager/utils/CaesarCipherTests.java
+++ b/src/test/java/com/atharvadholakia/password_manager/utils/CaesarCipherTests.java
@@ -8,15 +8,15 @@ public class CaesarCipherTests {
 
   @Test
   void testEncrypt() {
-    String plaintext = "HELLO";
-    String encryptedText = "KHOOR";
+    String plaintext = "TestPassword@1";
+    String encryptedText = "WhvwSdvvzrug@1";
     assertEquals(encryptedText, CaesarCipher.encrypt(plaintext, 3));
   }
 
   @Test
   void testDecrypt() {
-    String encryptedText = "KHOOR";
-    String plaintext = "HELLO";
+    String encryptedText = "WhvwSdvvzrug@1";
+    String plaintext = "TestPassword@1";
     assertEquals(plaintext, CaesarCipher.decrypt(encryptedText, 3));
   }
 }


### PR DESCRIPTION
This feature introduces a simple encryption technique "CaesarCipher" to the passwords stored and retrieved from the DB. 

### Key Changes
- **Added a CaesarCipher utility class which contains the logic of encryption and decryption.**
- **Added a EncryptionService utility service which calls CaeserCipher. Used in service layer to encrypt and decrypt the passwords.**

## The testcases are not passing because the password is now stored in the encrypted form.