### PR TITLE
Feature/passm 13 user login fetch salt

### DIFF
--- a/src/main/java/com/atharvadholakia/password_manager/controller/UserController.java
+++ b/src/main/java/com/atharvadholakia/password_manager/controller/UserController.java
@@ -3,16 +3,19 @@ package com.atharvadholakia.password_manager.controller;
 import com.atharvadholakia.password_manager.data.User;
 import com.atharvadholakia.password_manager.service.UserService;
 import jakarta.validation.Valid;
+import java.util.HashMap;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/register")
+@RequestMapping("/api")
 @Slf4j
 public class UserController {
 
@@ -22,7 +25,7 @@ public class UserController {
     this.userService = userService;
   }
 
-  @PostMapping
+  @PostMapping("/register")
   public ResponseEntity<User> registerUser(@Valid @RequestBody User user) {
     log.info(
         "Registering a user with Email: {} ,Hashed password: {}, Salt: {}",
@@ -37,5 +40,18 @@ public class UserController {
         registeredUser.getHashedPassword(),
         registeredUser.getSalt());
     return new ResponseEntity<>(registeredUser, HttpStatus.CREATED);
+  }
+
+  @GetMapping("/salt")
+  public ResponseEntity<HashMap<String, String>> getSaltByEmail(@RequestParam String email) {
+    log.info("Fetching salt by Email: {}", email);
+    String salt = userService.getSaltByEmail(email);
+
+    HashMap<String, String> response = new HashMap<>();
+
+    response.put("Salt", salt);
+
+    log.info("Successfully fetched salt by Email: {}", email);
+    return new ResponseEntity<>(response, HttpStatus.OK);
   }
 }

--- a/src/main/java/com/atharvadholakia/password_manager/controller/UserController.java
+++ b/src/main/java/com/atharvadholakia/password_manager/controller/UserController.java
@@ -25,7 +25,7 @@ public class UserController {
     this.userService = userService;
   }
 
-  @PostMapping
+  @PostMapping("/register")
   public ResponseEntity<HashMap<String, String>> registerUser(@Valid @RequestBody User user) {
     log.info(
         "Registering a user with Email: {} ,Hashed password: {}, Salt: {}",

--- a/src/main/java/com/atharvadholakia/password_manager/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/atharvadholakia/password_manager/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -67,6 +68,15 @@ public class GlobalExceptionHandler {
     response.put("email", ex.getMessage());
     log.error(ex.getMessage());
     return new ResponseEntity<>(response, HttpStatus.CONFLICT);
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  public ResponseEntity<HashMap<String, String>> handleMissingServletRequestParamterException(
+      MissingServletRequestParameterException ex) {
+    HashMap<String, String> response = new HashMap<>();
+    response.put("error", ex.getParameterName() + " parameter is missing.");
+
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
   }
 
   @ExceptionHandler(Exception.class)

--- a/src/main/java/com/atharvadholakia/password_manager/service/UserService.java
+++ b/src/main/java/com/atharvadholakia/password_manager/service/UserService.java
@@ -2,6 +2,7 @@ package com.atharvadholakia.password_manager.service;
 
 import com.atharvadholakia.password_manager.data.User;
 import com.atharvadholakia.password_manager.exception.EmailAlreadyExistsException;
+import com.atharvadholakia.password_manager.exception.ResourceNotFoundException;
 import com.atharvadholakia.password_manager.repository.UserRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,5 +26,23 @@ public class UserService {
 
     log.debug("Exiting registerUser from service.");
     return userRepository.save(newUser);
+  }
+
+  public User getUserByEmail(String email) {
+    User user =
+        userRepository
+            .findByEmail(email)
+            .orElseThrow(
+                () -> new ResourceNotFoundException("User not found with Email: " + email));
+
+    return user;
+  }
+
+  public String getSaltByEmail(String email) {
+    log.info("Calling getUserByEmail from service to get salt.");
+    User user = getUserByEmail(email);
+
+    log.debug("Exiting getSaltByEmail from service.");
+    return user.getSalt();
   }
 }

--- a/src/test/java/com/atharvadholakia/password_manager/controller/UserControllerTests.java
+++ b/src/test/java/com/atharvadholakia/password_manager/controller/UserControllerTests.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 


### PR DESCRIPTION
This PR introduces a new API endpoint to retrieve the stored salt for a user based on their email. The salt will be used by the frontend for secure password hashing during login.

## Changes Made: ##
- User Service: Developed a method in UserService to retrieve the salt and handle cases where the email is not found.
- Salt Retrieval Controller: Introduced an endpoint in UserController (GET /api/salt) that accepts an email as a query parameter and returns the salt in JSON format.
- Exception Handling: Returns a 404 response with an error message if the email is not found.